### PR TITLE
Add workflow to post new blog entries to Bluesky

### DIFF
--- a/.github/workflows/bluesky-post.yml
+++ b/.github/workflows/bluesky-post.yml
@@ -1,0 +1,26 @@
+name: Post new blog entries to Bluesky
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bluesky:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install gray-matter @atproto/api
+
+      - run: node scripts/post-to-bluesky.js
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/post-to-bluesky.js
+++ b/post-to-bluesky.js
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { execSync } from "child_process";
+import { BskyAgent } from "@atproto/api";
+
+const POSTS_DIR = "content/posts";
+const SITE_URL = "https://blog.imwiththou.com";
+
+// Detect newly added files only
+const diff = execSync("git diff --diff-filter=A --name-only HEAD~1 HEAD")
+  .toString()
+  .split("\n")
+  .filter(f => f.startsWith(POSTS_DIR));
+
+if (diff.length === 0) {
+  console.log("No new posts detected");
+  process.exit(0);
+}
+
+const agent = new BskyAgent({ service: "https://bsky.social" });
+
+await agent.login({
+  identifier: process.env.BLUESKY_HANDLE,
+  password: process.env.BLUESKY_APP_PASSWORD,
+});
+
+for (const file of diff) {
+  if (!file.endsWith(".md") && !file.endsWith(".mdx")) continue;
+
+  const raw = fs.readFileSync(file, "utf8");
+  const { data } = matter(raw);
+
+  const slug = path.basename(file, path.extname(file));
+  const url = `${SITE_URL}/posts/${slug}`;
+
+  const title = data.title ?? slug.replace(/-/g, " ");
+  const text = `📝 New blog post: ${title} ${url}`;
+
+  await agent.post({ text });
+  console.log(`Posted to Bluesky: ${title}`);
+}


### PR DESCRIPTION
Implement a GitHub Actions workflow that automatically posts new blog entries to Bluesky when they are added to the repository. This includes a script to detect new posts and publish them with the appropriate title and URL.