### PR TITLE
Add a new post on the ethical implications of AI and human accountability

### DIFF
--- a/content/posts/2026507-what-makes-us-humane.mdx
+++ b/content/posts/2026507-what-makes-us-humane.mdx
@@ -1,0 +1,26 @@
+---
+title: What makes us humane?
+description: Even if AI surpasses human performance, society may resist granting it full autonomy in high-stakes roles. The future will likely see a layered arrangement where AI performs much of the work, but humans remain at critical points of responsibility and meaning.
+date: "2026-05-07"
+---
+
+As artificial intelligence advances, the question is no longer what machines can do, but what we are willing to let them do. Across a surprisingly diverse set of professions—barbers, caregivers, nursery teachers, doctors, first responders, musicians, and priests—we observe a shared resistance to full automation. At first glance, these roles appear united by their reliance on physical presence, emotional intelligence, and long-term trust. Yet this explanation proves incomplete.
+
+A deeper pattern emerges when we include high-stakes professions such as paramedics, police officers, and surgeons. These roles are not simply “human-centered”; they are defined by operating under conditions of uncertainty, irreversibility, and moral consequence. In such environments, decisions are made in real time, often with lives at stake, and cannot be cleanly reduced to optimization problems. What binds these professions is not merely empathy, but accountability—the need for a human agent who can bear responsibility for outcomes.
+
+This introduces a structural paradox. Even if AI systems surpass human performance in diagnostic accuracy or reaction speed, society may still resist granting them full autonomy in these domains. The reason is not technical limitation, but moral architecture. Accountability is a human construct: we require a person to answer for decisions, to be judged, blamed, or forgiven. A machine, no matter how capable, cannot meaningfully occupy this role. It cannot be held morally responsible in a way that satisfies our collective sense of justice.
+
+However, this does not imply the emergence of a strictly “human-only sanctuary.” Rather, we are likely to see a reconfiguration of roles in which AI becomes deeply embedded in execution and analysis, while humans remain positioned at the boundary of responsibility. This model already exists in many forms: pilots oversee largely automated flights, doctors validate AI-assisted diagnoses, and organizations absorb liability for complex systems. Responsibility, in practice, is not eliminated by automation—it is reassigned.
+
+
+In this light, the crucial distinction is not who performs the task, but who has “skin in the game.” The humanity of these professions lies not solely in action, but in exposure—to error, to consequence, to the weight of decision. A doctor who approves an AI-generated diagnosis still carries the burden of being wrong. A paramedic guided by algorithmic triage still faces the moral reality of life and death. Human vulnerability persists, even as human control becomes more distributed.
+
+Yet beyond accountability lies another, more elusive boundary: meaning. Certain roles are not valued purely for their outcomes, but for the nature of the interaction itself. A barber does more than cut hair; a caregiver does more than maintain health; a musician does more than produce sound. These are encounters between conscious beings who recognize each other as such—what might be called intersubjective experiences. They involve shared awareness of time, mortality, identity, and presence.
+
+Even a perfectly capable AI may fail here, not because it lacks intelligence, but because it lacks being. It does not age, suffer, or exist within the same horizon of human experience. As a result, it cannot fully participate in the subtle, reciprocal recognition that defines these interactions. In such contexts, replacing the human risks not just inefficiency or discomfort, but a loss of meaning.
+
+The future, then, is unlikely to be divided cleanly between human and machine domains. Instead, it will be layered. AI will permeate systems of care, decision-making, and production, often performing the majority of computational work. But humans will remain visible at critical points—where responsibility must be assigned, where judgment must be justified, and where presence itself carries value.
+
+This arrangement reflects a deeper tension that may never be resolved. Technological systems optimize for efficiency, accuracy, and scale. Human systems, by contrast, are structured around meaning, accountability, and social coherence. As AI continues to advance, we will not eliminate this tension; we will institutionalize it.
+
+In the end, what we preserve is not simply human labor, but the conditions under which human life remains intelligible to itself. We do not only seek correct outcomes—we seek someone who can answer for them, and someone who can stand with us within them.


### PR DESCRIPTION
Introduce a discussion on the balance between AI capabilities and human responsibility, emphasizing the importance of accountability and meaning in high-stakes professions. The post explores how AI can enhance roles while humans remain essential for moral and ethical decision-making.