### PR TITLE
Add SingaporeTime component to About page

### DIFF
--- a/components/SingaporeTime.tsx
+++ b/components/SingaporeTime.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+const SINGAPORE_TIME_ZONE = "Asia/Singapore"
+const SINGAPORE_UTC_OFFSET_HOURS = 8
+
+function getReaderOffsetHours() {
+  return -new Date().getTimezoneOffset() / 60
+}
+
+function formatHourDifference(hours: number) {
+  const absoluteHours = Math.abs(hours)
+
+  if (Number.isInteger(absoluteHours)) {
+    return absoluteHours.toString()
+  }
+
+  return absoluteHours.toFixed(1)
+}
+
+function getOffsetCopy(readerOffsetHours: number) {
+  const hourDifference = readerOffsetHours - SINGAPORE_UTC_OFFSET_HOURS
+
+  if (hourDifference === 0) {
+    return "you are in the same time as me"
+  }
+
+  const direction = hourDifference > 0 ? "ahead of" : "behind"
+  const hourLabel = Math.abs(hourDifference) === 1 ? "hour" : "hours"
+
+  return `you are ${formatHourDifference(hourDifference)} ${hourLabel} ${direction} me`
+}
+
+export default function SingaporeTime() {
+  const [now, setNow] = useState<Date | null>(null)
+
+  useEffect(() => {
+    setNow(new Date())
+
+    const interval = window.setInterval(() => {
+      setNow(new Date())
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const singaporeTime = useMemo(() => {
+    if (!now) {
+      return "--:--:--"
+    }
+
+    return new Intl.DateTimeFormat("en-SG", {
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: true,
+      timeZone: SINGAPORE_TIME_ZONE,
+      timeZoneName: "short",
+    }).format(now)
+  }, [now])
+
+  const readerOffsetCopy = useMemo(() => {
+    if (!now) {
+      return "calculating your distance from Singapore time"
+    }
+
+    return getOffsetCopy(getReaderOffsetHours())
+  }, [now])
+
+  return (
+    <section className="not-prose my-10 border-y border-zinc-200 py-6 text-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+      <p className="m-0 text-sm uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
+        Singapore time
+      </p>
+      <p className="mt-3 mb-2 font-mono text-3xl font-semibold leading-tight">
+        {singaporeTime}
+      </p>
+      <p className="m-0 text-base text-zinc-600 dark:text-zinc-300">
+        {readerOffsetCopy}
+      </p>
+    </section>
+  )
+}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -2,11 +2,13 @@ import Image from "next/image"
 import { useMDXComponent } from "next-contentlayer/hooks"
 import FigureWithCaption from "./FigureWithCaption"
 import AudioPlayer from "./AudioPlayer"
+import SingaporeTime from "./SingaporeTime"
 
 const components = {
   Image,
   FigureWithCaption,
   AudioPlayer,
+  SingaporeTime,
 }
 
 interface MdxProps {

--- a/content/pages/about.mdx
+++ b/content/pages/about.mdx
@@ -55,4 +55,6 @@ Of course not being a fan of pop music doesn’t mean I do no listen to them. Ju
 
 I want to know the world in my own way, not the way of being taught or told.
 
+<SingaporeTime />
+
 Reach out to me via <a rel="bluesky" href="https://bsky.app/profile/stevewang.bsky.social">Bluesky</a> or drop me a text via [iMessage](sms:steve@imwiththou.com).


### PR DESCRIPTION
Introduce a new SingaporeTime component that displays the current time in Singapore and the user's time difference from it. Integrate this component into the About page for enhanced user experience.