### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single **Next.js 13 (App Router) + Contentlayer** static blog written in
+TypeScript and styled with Tailwind. There is no backend, database, or auth — all content
+lives as MDX files under `content/` (`content/posts`, `content/pages`, `content/staging`).
+
+### Services
+
+There is only one service: the Next.js app. Standard scripts live in `package.json`
+(`dev`, `build`, `start`, `preview`, `lint`).
+
+- Run dev server: `npm run dev` (serves on `http://localhost:3000`).
+- Lint: `npm run lint`.
+- Build: `npm run build` (also runs Contentlayer generation, then produces the static site).
+
+### Non-obvious notes
+
+- Use **npm**, not pnpm, for local dev. `package.json` declares `"packageManager": "pnpm@7.5.1"`,
+  but the committed lockfile is `package-lock.json` (npm) and CI uses npm. Stick with npm to match the lockfile.
+- Contentlayer 0.3.2 runs fine on the VM's Node v22 — build and dev both succeed despite the older CI (Node 20).
+- Contentlayer runs automatically inside `next dev` / `next build` (via `withContentlayer` in
+  `next.config.js`); there is no separate content-build command. Generated output goes to
+  `.contentlayer/generated`.
+- Authoring a post = add an MDX file to `content/posts/` with frontmatter `title`, `date`
+  (required) and optional `description`. The dev server hot-reloads and the post appears at
+  `/posts/<filename-without-extension>`.
+- `.github/workflows/bluesky-post.yml` is CI-only automation (posts new entries to Bluesky) and
+  is unrelated to running the app locally. Note it references `scripts/post-to-bluesky.js` while
+  the script actually lives at the repo root (`post-to-bluesky.js`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js 13 + Contentlayer blog and documents durable, non-obvious guidance for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the single service (Next.js app), standard scripts, and non-obvious notes (use npm not pnpm, Contentlayer runs inside `next dev`/`next build`, how to author a post, Node 22 compatibility, Bluesky CI caveat).
- Update script for future VM boots: `npm install`.

## Verification

- `npm install` — dependencies installed (799 packages).
- `npm run lint` — passes (one `<img>` warning only).
- `npm run build` — succeeds; Contentlayer generated 49 documents and all 59 static pages rendered.
- `npm run dev` — served on `http://localhost:3000`; home page (`200`), `/api/hello` (`200`).
- Hello-world task: authored a temporary MDX post, confirmed it hot-reloaded and rendered at its post URL, then removed the temporary post.

[blog_dev_server_demo.mp4](https://cursor.com/agents/bc-c02146ec-9c39-41a4-aef7-cd468e93eafe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dev_server_demo.mp4)

[Blog home page](https://cursor.com/agents/bc-c02146ec-9c39-41a4-aef7-cd468e93eafe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_home_page.webp)
[Rendered new post](https://cursor.com/agents/bc-c02146ec-9c39-41a4-aef7-cd468e93eafe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_new_post.webp)

No application code was modified; only `AGENTS.md` was added.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02146ec-9c39-41a4-aef7-cd468e93eafe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02146ec-9c39-41a4-aef7-cd468e93eafe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

