### PR TITLE
Increase space below the top nav

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -49,7 +49,7 @@ export default async function PagePage({ params }: PageProps) {
   }
 
   return (
-    <article className="py-6 prose dark:prose-invert">
+    <article className="pb-6 prose dark:prose-invert">
       <h4>{page.title}</h4>
       {page.description && <p className="text-base">{page.description}</p>}
       <hr />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased min-h-screen bg-white dark:bg-black text-slate-950 dark:text-slate-50">
         <div className="max-w-3xl mx-auto py-10 px-4">
-            <header className="w-full mb-10">
+            <header className="w-full">
               <div className="flex items-center justify-between">
                 <nav className="ml-auto text-sm font-medium space-x-2">
                   <Link href="/" className="px-4 py-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition no-underline">Home</Link>
@@ -30,7 +30,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 </nav>
               </div>
             </header>
-            <main className="w-full">
+            <main className="w-full pt-24">
               {children}
               <br />
               <span className="text-xs uppercase tracking-wide text-slate-400 mb-8">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased min-h-screen bg-white dark:bg-black text-slate-950 dark:text-slate-50">
         <div className="max-w-3xl mx-auto py-10 px-4">
-            <header className="w-full">
+            <header className="w-full mb-10">
               <div className="flex items-center justify-between">
                 <nav className="ml-auto text-sm font-medium space-x-2">
                   <Link href="/" className="px-4 py-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition no-underline">Home</Link>

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -52,7 +52,7 @@ export default async function PostPage({ params }: PostProps) {
   }
 
   return (
-    <article className="py-6 prose dark:prose-invert">
+    <article className="pb-6 prose dark:prose-invert">
       <h1 className="mb-2">{post.title}</h1>
       {post.description && (
         <p className="text-xl mt-0 text-slate-700 dark:text-slate-200">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first post title sits in an `h4` with Tailwind Preflight’s zero margins, so a 40px header margin was not enough (and sibling margins can collapse).

`main` now has `pt-24` (6rem) so Home, posts, About, and Quotes all get a clear gap below the nav. Article `py-6` is now `pb-6` so inner pages don’t add extra top padding on top of that.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf7902e2-10fb-4032-ad66-a4f2f80df048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf7902e2-10fb-4032-ad66-a4f2f80df048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

